### PR TITLE
Test mode, blocking processes/devices and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,10 +251,11 @@ Some other improvements I'm thinking about, but won't implement unless there is 
 
 ### 1.3 (xx March 2026)
 - Added connectivity tests to check if Plex is running and the supplied token is valid.
-- Improved the formatting of the output to make troubleshooting easier.
+- Improved the formatting of the output to make troubleshooting and logging easier.
 - Added support for blocking shutdown if certain processes are running.
 - Added support for blocking shutdown if certain devices are on the network (e.g. a television).
 - Added a test mode to enable verification of the logic without shutting down the server.
+- Removed use of deprecated `wmic` command and replaced it with PowerShell for uptime checks (Windows). 
 - Updated the documentation.
 
 ### 1.2 (28th March 2025)

--- a/README.md
+++ b/README.md
@@ -55,10 +55,16 @@ You do not have to edit any of these settings. The script works fine with the de
 > If you set this value too low, then your server may turn off very quickly after you have turned it back on.
 
 - **`BLOCKING_PROCESSES`**  
-  A semi-colon (`;`) separated list of processes that will block shutdown if they are running. This is useful for delaying shutdown until certain tasks (either Plex related or not) finish. The default code includes `Plex Transcoder` here to ensure that the server isn’t incorrectly shut down while Plex is transcoding - even if the Plex API reports no activity.
+  A semi-colon (`;`) separated list of processes that will block shutdown if they are running. This can be used to delay shutdown until certain tasks finish, whether Plex-related or not. Multiple processes can be listed, and the script will prevent shutdown if any are running.
+
+>[!NOTE]
+>The default script includes `Plex Transcoder` to prevent the server from shutting down while Plex is transcoding, even if the Plex API incorrectly reports no activity.
 
 - **`BLOCKING_ADDRESSES`**  
-  A semi-colon (`;`) separated list of devices that will block shutdown if they are active. Each entry can be an IP address or hostname (e.g. `192.168.0.20;SAMSUNG-TV`) and devices on this list are assumed to be in use if they respond to a network [ping](https://www.lifewire.com/ping-command-2618099). If you want to use IP addresses then it is recommended to configure your router to assign a static (same) IP address to the device to stop it changing.
+  A semi-colon (`;`) separated list of devices that will block shutdown if they are active. Each entry can be an IP address or hostname (e.g. `192.168.0.20;SAMSUNG-TV`). Devices on this list are considered "in use" if they respond to a network [ping](https://www.lifewire.com/ping-command-2618099). Multiple devices can be listed, and the script will prevent shutdown if any respond.
+
+>[!TIP]
+>If you are using IP addresses, assign a static IP to each device (via your router) to prevent the address from changing.
 
 ## ▶️ Running the script
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,13 @@
 
 <p><img src="https://img.shields.io/badge/Windows-supported-0078D6?logo=windows&logoColor=white" alt="Windows"> <img src="https://img.shields.io/badge/Linux-supported-FCC624?logo=linux&logoColor=black" alt="Linux"> <img src="https://img.shields.io/badge/License-Unlicense-000000?logo=unlicense&logoColor=white" alt="Unlicense"> <img src="https://img.shields.io/github/stars/mrsilver76/plex-autoshutdown"></p>
 
-*A simple script which will check that no-one is using Plex before shutting down the server it is running on.*
+*A simple script that automatically shuts down your Plex server when no one is using it.*
 
-This script is useful for people who have no requirement to run their Plex server 24/7 and have periods of time where no-one is using their server (e.g. the early hours of the morning).
+This script checks for active streams and other activity before powering off the machine, making it useful for servers that do not need to run 24/7 and sit idle for long periods (typically overnight).
 
-**There are two scripts, one for Windows uses and one for Linux users.** The Linux one may work with macOS, but I have no way of verifying. I'm happy to take a submission/fix from someone who owns one. 
+**There are two scripts, one for Windows and one for Linux.** The Linux version may also work on macOS, but this has not been tested. Contributions from macOS users are welcome.
 
 ## 🧰 Features
-
-Despite being small, these scripts have some useful features:
 
 * 🖥️ Works on Windows and Linux (and possibly macOS)
 * ⚙️ Easy to set up, there is only one option that you _**must**_ configure.
@@ -18,14 +16,14 @@ Despite being small, these scripts have some useful features:
 * 📥 Will not shut down a server if there are active Plex downloads.
 * 📺 Will not shut down a server if live TV is being watched or recorded.
 * 🧩 Will not shut down a server if certain processes (Plex related or not) are running.
-* 🏠 Will not shutdown a server if certain devices are active on the network (e.g. a smart TV with network access).
+* 🏠 Will not shutdown a server if certain devices are active on the network (e.g. a smart TV or streaming device).
 * ⏳ Will not force a server to shut down for a configurable period of time after power up.
 * 🧪 Test mode to verify the logic without accidentally powering off your server.
 
 ## 📦 Download
 
-1. Get the latest version from https://github.com/mrsilver76/plex-autoshutdown/releases. Windows users should download the zip file, Linux users should download the tar.gz file.
-3. Decompress the file. On Windows, you can double-click the file. On Linux you should use the `gunzip` command.
+1. Download the latest version from the [Releases page](https://github.com/mrsilver76/plex-autoshutdown/releases) page. Both archives contain the same files. The `.zip` file is generally easiest for Windows users, while Linux users will typically use the `.tar.gz` version.
+2. Decompress the file. On Windows, you should right-click on the file and select "Extract All...". On Linux you should use the `gunzip` command.
 4. Use the file ending in `.bat` for Windows and the file ending `.sh` for Linux.
 
 ## ⚙️ Configuration
@@ -68,9 +66,8 @@ The script must be placed and run on your Plex server (the same machine Plex is 
 
 On Linux, you will need to make it executable first by using `chmod +x plex-autoshutdown.sh`.
 
-**Before setting up the script to run automatically, run it in test mode from the command line to confirm everything works correctly!**
-
-When test mode is enabled, the script performs all checks and reports what it would do. Even if a condition would normally block a shutdown, the script will continue running so you can see the full set of results. _**It will never actually shut down your server in this mode!**_
+⚠️ **Before scheduling the script to run automatically, run it in test mode to ensure everything works as expected.**<br>
+Test mode performs all the same checks as normal mode but will not shut down your server, letting you safely experiment with settings and scenarios.
 
 To use test mode, append any of `/t`, `/test`, `-t`, or `--test` to the command line, irrespective of your operating system:
 
@@ -229,8 +226,8 @@ This approach keeps your logs manageable while preserving recent history for tro
 ## ⚠️ Known issues
 
 - The Plex API may continue reporting that content is being streamed for several minutes after playback stops. There is no workaround for this.
-- The Plex API may fail to report active transcoding. To prevent shutdown during transcoding, the `Plex Transcoder` entry in `BLOCKING_PROCESSES` acts as an effective workaround.
-- The script will not work if "Secured connections" is set to "Required" within Plex.
+- The Plex API may fail to report active transcoding. The workaround for this is the inclusion of the `Plex Transcoder` entry in the `BLOCKING_PROCESSES` setting.
+- The script will not work if "Secured connections" is set to "Required" within Plex. This is a possible future development (subject to demand).
 
 ## 🛟 Questions/problems?
 
@@ -244,7 +241,7 @@ Some other improvements I'm thinking about, but won't implement unless there is 
 
 - **Support for secured connections.** This would enable the script to work even if "Secured connections" is set to "Required" within the Plex server.
 - **Support for non-pingable devices.** Allow specification of a port number which can then be used to probe a device that ignores `ping` requests.
-- **Migrate Windows batch to Powershell.** Move the Windows version to the more featureful, robust and saner Powershell format.
+- **Migrate Windows script to PowerShell.** Replace the current batch implementation with PowerShell to improve reliability, maintainability and access to modern Windows features.
 - **Configurable behavior when Plex is unreachable/down.** Allow the script to either exit and leave the server running or proceed with shutdown when Plex cannot be contacted.
 - **Report number of streams rather than just checking for 0.** Instead of only detecting whether there are zero streams, report how many active streams are running so you can decide based on count thresholds. 
 - **Output to logs instead of screen.** Remove the need to redirect output by allowing configuration in the script to output logs to terminal, file, both or none. Handle log rotation automatically.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You do not have to edit any of these settings. The script works fine with the de
   A semi-colon (`;`) separated list of processes that will block shutdown if they are running. This is useful for delaying shutdown until certain tasks (either Plex related or not) finish. The default code includes `Plex Transcoder` here to ensure that the server isn’t incorrectly shut down while Plex is transcoding - even if the Plex API reports no activity.
 
 - **`BLOCKING_ADDRESSES`**  
-  A semi-colon (`;`) separated list of devices that will block shutdown if they are active. Each entry can be an IP address or hostname (e.g. `192.168.0.20;SAMSUNG-TV`) and devices on this list are assumed to be in use if they respond to [ping](https://www.lifewire.com/ping-command-2618099) or appear in [ARP](https://en.wikipedia.org/wiki/Address_Resolution_Protocol). If you want to use IP addresses then it is recommended to configure your router to assign a static (same) IP address to the device to stop it changing.
+  A semi-colon (`;`) separated list of devices that will block shutdown if they are active. Each entry can be an IP address or hostname (e.g. `192.168.0.20;SAMSUNG-TV`) and devices on this list are assumed to be in use if they respond to a network [ping](https://www.lifewire.com/ping-command-2618099). If you want to use IP addresses then it is recommended to configure your router to assign a static (same) IP address to the device to stop it changing.
 
 ## ▶️ Running the script
 
@@ -243,6 +243,7 @@ This script currently meets the needs it was designed for, and no major new feat
 Some other improvements I'm thinking about, but won't implement unless there is demand, are:
 
 - **Support for secured connections.** This would enable the script to work even if "Secured connections" is set to "Required" within the Plex server.
+- **Support for non-pingable devices.** Allow specification of a port number which can then be used to probe a device that ignores `ping` requests.
 - **Configurable behavior when Plex is unreachable/down.** Allow the script to either exit and leave the server running or proceed with shutdown when Plex cannot be contacted.
 - **Report number of streams rather than just checking for 0.** Instead of only detecting whether there are zero streams, report how many active streams are running so you can decide based on count thresholds. 
 - **Output to logs instead of screen.** Remove the need to redirect output by allowing configuration in the script to output logs to terminal, file, both or none. Handle log rotation automatically.

--- a/README.md
+++ b/README.md
@@ -261,7 +261,9 @@ Some other improvements I'm thinking about, but won't implement unless there is 
 
 ### 1.3 (xx March 2026)
 - Added connectivity tests to check if Plex is running and the supplied token is valid.
+- Added validation that the supplied Plex token is not blank or set to the placeholder.
 - Improved the formatting of the output to make troubleshooting and logging easier.
+- Adjusted the logic so all checks run even if earlier ones fail, making it easier to see every reason shutdown might be blocked.
 - Added support for blocking shutdown if certain processes are running.
 - Added support for blocking shutdown if certain devices are on the network (e.g. a television).
 - Added a test mode to enable verification of the logic without shutting down the server.

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ The easiest way is to change your BIOS settings to power on the server at a spec
 You can usually find the power-on scheduling option in your BIOS under a "Power" or "Advanced" menu, often called something like "Resume by RTC Alarm", "Wake on RTC", or "Wake on Alarm". If you don’t see it, check any "Power Management" or "ACPI" sections. 
 
 > [!TIP]
-> Whilst you are configuring this, I recommend you also enable the “automatically power on after power loss” option. This means that if you have a power cut then the server will automatically boot again when power is restored.
-
+> - Turn on “automatic power on after power loss” in the BIOS so the server will restart automatically if the electricity goes out.
+> - Ensure Plex tasks don’t try to run while the server is off! Schedule them to start about 5 minutes after it powers on.
 
 ## 📝 Logging
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ If you do decide you need to review the output (e.g. to troubleshoot an issue), 
 
 Make sure you use `>>` and not `>`, as the latter will overwrite the log file every time the script is run.
 
+<!--
+
 ### Long term logging (advanced users)
 
 If you leave this redirect in place long term, the log file will continue to grow. It will not grow quickly, but over time it will become unnecessarily large.
@@ -222,6 +224,8 @@ mv "$CURRENT_LOG" "$OLD_LOG"
 
 This approach keeps your logs manageable while preserving recent history for troubleshooting. You can schedule these scripts using Task Scheduler on Windows or cron on Linux.
 
+-->
+
 ## ⚠️ Known issues
 
 - The Plex API may continue reporting that content is being streamed for several minutes after playback stops. There is no workaround for this.
@@ -239,6 +243,7 @@ This script currently meets the needs it was designed for, and no major new feat
 Some other improvements I'm thinking about, but won't implement unless there is demand, are:
 
 - **Support for secured connections.** This would enable the script to work even if "Secured connections" is set to "Required" within the Plex server.
+- **Configurable behavior when Plex is unreachable/down.** Allow the script to either exit and leave the server running or proceed with shutdown when Plex cannot be contacted.
 - **Report number of streams rather than just checking for 0.** Instead of only detecting whether there are zero streams, report how many active streams are running so you can decide based on count thresholds. 
 - **Output to logs instead of screen.** Remove the need to redirect output by allowing configuration in the script to output logs to terminal, file, both or none. Handle log rotation automatically.
 - **Sleep option, instead of power down.** Provide an option to put the server into sleep/standby rather than fully powering it down when no active streams are detected. 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Some other improvements I'm thinking about, but won't implement unless there is 
 
 - **Support for secured connections.** This would enable the script to work even if "Secured connections" is set to "Required" within the Plex server.
 - **Support for non-pingable devices.** Allow specification of a port number which can then be used to probe a device that ignores `ping` requests.
+- **Migrate Windows batch to Powershell.** Move the Windows version to the more featureful, robust and saner Powershell format.
 - **Configurable behavior when Plex is unreachable/down.** Allow the script to either exit and leave the server running or proceed with shutdown when Plex cannot be contacted.
 - **Report number of streams rather than just checking for 0.** Instead of only detecting whether there are zero streams, report how many active streams are running so you can decide based on count thresholds. 
 - **Output to logs instead of screen.** Remove the need to redirect output by allowing configuration in the script to output logs to terminal, file, both or none. Handle log rotation automatically.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Despite being small, these scripts have some useful features:
 * 🧩 Will not shut down a machine if certain processes (Plex related or not) are running.
 * 🏠 Will not shutdown a machine if certain devices are active on the network (e.g. a television).
 * ⏳ Will not force a machine to shut down for a (configurable) period of time after power up.
+* 🧪 Test mode to verify the logic without accidentally powering off your machine.
 
 ## 📦 Download
 
@@ -155,6 +156,7 @@ Some other improvements I'm thinking about, but won't implement unless there is 
 - Improved the formatting of the output to make troubleshooting easier.
 - Added support for blocking shutdown if certain processes are running.
 - Added support for blocking shutdown if certain devices are on the network (e.g. a television).
+- Added a test mode to enable verification of the logic without shutting down the server.
 - Updated the documentation.
 
 ### 1.2 (28th March 2025)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Plex Autoshutdown
 
-<p><img src="https://img.shields.io/badge/Windows-supported-0078D6?logo=windows&logoColor=white" alt="Windows"> <img src="https://img.shields.io/badge/Linux-supported-FCC624?logo=linux&logoColor=black" alt="Linux"> <img src="https://img.shields.io/badge/License-Unlicense-000000?logo=unlicense&logoColor=white" alt="Unlicense"></p>
+<p><img src="https://img.shields.io/badge/Windows-supported-0078D6?logo=windows&logoColor=white" alt="Windows"> <img src="https://img.shields.io/badge/Linux-supported-FCC624?logo=linux&logoColor=black" alt="Linux"> <img src="https://img.shields.io/badge/License-Unlicense-000000?logo=unlicense&logoColor=white" alt="Unlicense"> <img src="https://img.shields.io/github/stars/mrsilver76/plex-autoshutdown"></p>
 
 *A simple script which will check that no-one is using Plex before shutting down the server it is running on.*
 
-This script is useful for people who have no requirement to run their Plex server 24/7 and have periods of time where no-one is using their server (eg. the early hours of the morning).
+This script is useful for people who have no requirement to run their Plex server 24/7 and have periods of time where no-one is using their server (e.g. the early hours of the morning).
 
 **There are two scripts, one for Windows uses and one for Linux users.** The Linux one may work with macOS, but I have no way of verifying. I'm happy to take a submission/fix from someone who owns one. 
 
@@ -14,13 +14,13 @@ Despite being small, these scripts have some useful features:
 
 * 🖥️ Works on Windows and Linux (and possibly macOS)
 * ⚙️ Easy to set up, there is only one option that you _**must**_ configure.
-* 🎬 Will not shut down a machine if there are active Plex streams (audio or video).
-* 📥 Will not shut down a machine if there are active Plex downloads.
-* 📺 Will not shut down a machine if live TV is being watched or recorded.
-* 🧩 Will not shut down a machine if certain processes (Plex related or not) are running.
-* 🏠 Will not shutdown a machine if certain devices are active on the network (e.g. a television).
-* ⏳ Will not force a machine to shut down for a (configurable) period of time after power up.
-* 🧪 Test mode to verify the logic without accidentally powering off your machine.
+* 🎬 Will not shut down a server if there are active Plex streams (audio or video).
+* 📥 Will not shut down a server if there are active Plex downloads.
+* 📺 Will not shut down a server if live TV is being watched or recorded.
+* 🧩 Will not shut down a server if certain processes (Plex related or not) are running.
+* 🏠 Will not shutdown a server if certain devices are active on the network (e.g. a smart TV with network access).
+* ⏳ Will not force a server to shut down for a configurable period of time after power up.
+* 🧪 Test mode to verify the logic without accidentally powering off your server.
 
 ## 📦 Download
 
@@ -34,7 +34,7 @@ To configure the script, open it up in your preferred text editor. For Windows, 
 
 ### Basic configuration options
 
-Only one setting is required to get this script running. You can leave everything else as-is and the script will work perfectly fine.
+**Only one setting is required to get this script running. You can leave everything else as-is and the script will work perfectly fine.**
 
 - **`PLEX_TOKEN`**  
   The script uses the Plex API in order to determine whether or not anything is streaming. To do this, it needs a token to use for authentication. Plex provides instructions on how to find the token for your Plex server [here](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/). 
@@ -44,7 +44,7 @@ Only one setting is required to get this script running. You can leave everythin
 > [!CAUTION]
 > You should never share your Plex token with anyone else.
 
-### Advanced configuration options
+### Optional advanced configuration options
 
 You do not have to edit any of these settings. The script works fine with the defaults and these options are only for fine-tuning behaviour.
 
@@ -64,11 +64,13 @@ You do not have to edit any of these settings. The script works fine with the de
 
 ## ▶️ Running the script
 
-The script must be placed and run on your Plex server (the same machine Plex is installed on) to correctly detect streams, downloads and other activity. 
+The script must be placed and run on your Plex server (the same machine Plex is installed on) to correctly detect streams, downloads, processes running and other activity. 
 
 On Linux, you will need to make it executable first by using `chmod +x plex-autoshutdown.sh`.
 
-Before enabling automatic shutdown, run the script in test mode from the command line to confirm that everything is working correctly. When test mode is enabled, the script performs all checks and reports what it would do. Even if a condition would normally block a shutdown, the script will continue running so you can see the full set of results. _**It will never actually shut down your server in this mode!**_
+**Before setting up the script to run automatically, run it in test mode from the command line to confirm everything works correctly!**
+
+When test mode is enabled, the script performs all checks and reports what it would do. Even if a condition would normally block a shutdown, the script will continue running so you can see the full set of results. _**It will never actually shut down your server in this mode!**_
 
 To use test mode, append any of `/t`, `/test`, `-t`, or `--test` to the command line, irrespective of your operating system:
 
@@ -89,7 +91,7 @@ You need to set up a scheduled task to run the script:
 - Click on “Start”, type “Task” and select “Task Scheduler”.
 - Click on “Create Task”.
 - Set the Name to: “Plex Autoshutdown”.
-- Set the Description to: “Automatically shut down this machine if Plex is not running”.
+- Set the Description to: “Automatically shut down this server if Plex is not running”.
 - If you run Plex without logging a user in, then you will need to enable “Run whether user is logged in or not”.
 - Click on the “Trigger” tab.
 - Click on “New”.
@@ -125,9 +127,9 @@ As the script outputs messages, this will be emailed to you. The use of `>/dev/n
 
 ## 🔌 Automatic power on
 
-Once you have the script set up to shut down your machine, you also need some way to start it back up again in the morning.
+Once you have the script set up to shut down your server at night, you also need some way to start the server back up again in the morning.
 
-The easiest way is to change your BIOS settings to power on the machine at a specific time. To access the BIOS, you will usually need to press a key such as <kbd>Del</kbd>, <kbd>F1</kbd>, <kbd>F2</kbd>, <kbd>F10</kbd> or <kbd>Esc</kbd> immediately after powering on. If you’re unsure which key to use for your computer or motherboard, check the manufacturer’s instructions or search online.
+The easiest way is to change your BIOS settings to power on the server at a specific time. To access the BIOS, you will usually need to press a key such as <kbd>Del</kbd>, <kbd>F1</kbd>, <kbd>F2</kbd>, <kbd>F10</kbd> or <kbd>Esc</kbd> immediately after powering on. If you’re unsure which key to use for your computer or motherboard, check the manufacturer’s instructions or search online.
 
 You can usually find the power-on scheduling option in your BIOS under a "Power" or "Advanced" menu, often called something like "Resume by RTC Alarm", "Wake on RTC", or "Wake on Alarm". If you don’t see it, check any "Power Management" or "ACPI" sections. 
 
@@ -141,49 +143,82 @@ The script outputs information to the terminal or console, showing whether any s
 
 If you do decide you need to review the output (e.g. to troubleshoot an issue), you can redirect the output to a file by appending a redirect to the end of the command:
 
-- Windows: `plex-autoshutdown.bat > "C:\path\to\logs\autoshutdown.log" 2>&1`
-- Linux: `./plex-autoshutdown.sh > /path/to/logs/autoshutdown.log 2>&1`
+- Windows: `plex-autoshutdown.bat >> "C:\path\to\logs\autoshutdown.log" 2>&1`
+- Linux: `./plex-autoshutdown.sh >> /path/to/logs/autoshutdown.log 2>&1`
 
-If you intend to keep this redirect in place indefinitely then, over time, the log file will grow very large. To prevent this, you can use a simple rotation script that runs daily to archive old logs and keep only recent entries. The following code should be called once a day (for example, on start up), assumes that you write out to `autoshutdown.log` and will maintain up to 7 days of history.
+Make sure you use `>>` and not `>`, as the latter will overwrite the log file every time the script is run.
+
+### Long term logging (advanced users)
+
+If you leave this redirect in place long term, the log file will continue to grow. It will not grow quickly, but over time it will become unnecessarily large.
+
+A simple way to manage this is monthly rotation based on the file’s last modified date. When the month changes, the current log is renamed and a fresh one starts. This keeps up to two months of logs, which is usually more than enough for troubleshooting.
+
+The scripts below implement this approach. Configure your server to run the appropriate script at startup.
+
+>[!NOTE]
+>Rotation is triggered the first time the server starts in a new month. If there are log entries written in the early hours of the first day of the new month (so before rotation runs) then those entries will be moved into the previous month’s file. They are not lost, but they will appear in the rotated log rather than the new current one.
 
 **Windows** (save as `rotate-autoshutdown.bat`)
 ```batch
 @echo off
+setlocal
 
-set "LOG_DIR=C:\path\to\logs"
-set "LOG_FILE=%LOG_DIR%\autoshutdown.log"
+rem ----- Configuration --------------------
 
-rem Delete the oldest log
-del "%LOG_DIR%\autoshutdown-7.log" 2>nul
+set "LOG_DIR=C:\Logs"
+set "LOG_FILE=autoshutdown.log"
 
-rem Shift logs up by one
-for /l %%i in (6,-1,1) do (
-    ren "%LOG_DIR%\autoshutdown-%%i.log" "autoshutdown-%%~ni%%i+.log" 2>nul
-)
+rem ----- End configuration ----------------
 
-rem Move today's log to autoshutdown-1.log
-move "%LOG_FILE%" "%LOG_DIR%\autoshutdown-1.log" 2>nul
+set "CURRENT_LOG=%LOG_DIR%\%LOG_FILE%"
+set "OLD_LOG=%LOG_DIR%\autoshutdown.old.log"
+
+rem Exit if there is no current log file
+if not exist "%CURRENT_LOG%" goto :eof
+
+rem Get today's date and the last modified date of the log (in format YY-MM)
+for /f %%A in ('powershell -NoProfile -Command "Get-Date -Format yyyy-MM"') do set "NOW_YYYYMM=%%A"
+for /f %%A in ('powershell -NoProfile -Command "(Get-Item \"%CURRENT_LOG%\").LastWriteTime.ToString(\"yyyy-MM\")"') do set "LOG_YYYYMM=%%A"
+
+# Exit if the dates are different
+if "%NOW_YYYYMM%"=="%LOG_YYYYMM%" goto :eof
+
+# Remove old log and move current one to old
+if exist "%OLD_LOG%" del "%OLD_LOG%"
+move "%CURRENT_LOG%" "%OLD_LOG%" >nul
+
+endlocal
 ```
 
 **Linux** (save as `rotate-autoshutdown.sh`)
 ```bash
 #!/bin/bash
 
-LOG_DIR="/path/to/logs"
-LOG_FILE="$LOG_DIR/autoshutdown.log"
+# ----- Configuration --------------------
 
-# Delete the oldest log
-rm -f "$LOG_DIR/autoshutdown-7.log"
+LOG_DIR="/var/log"
+LOG_FILE="autoshutdown.log"
 
-# Shift logs up by one
-for i in 6 5 4 3 2 1; do
-    mv "$LOG_DIR/autoshutdown-$i.log" "$LOG_DIR/autoshutdown-$((i+1)).log" 2>/dev/null
-done
+# ----- End configuration ----------------
 
-# Move today's log to autoshutdown-1.log
-mv "$LOG_FILE" "$LOG_DIR/autoshutdown-1.log" 2>/dev/null
+CURRENT_LOG="$LOG_DIR/$LOG_FILE"
+OLD_LOG="$LOG_DIR/autoshutdown.old.log"
+
+# Exit if there is no current log file
+[ ! -f "$CURRENT_LOG" ] && exit 0
+
+# Get today's date and the last modified date of the log (in format YY-MM)
+NOW_YYYYMM=$(date +"%Y-%m")
+LOG_YYYYMM=$(date -r "$CURRENT_LOG" +"%Y-%m")
+
+# Exit if the dates are different
+[ "$NOW_YYYYMM" = "$LOG_YYYYMM" ] && exit 0
+
+# Remove old log and move current one to old
+[ -f "$OLD_LOG" ] && rm -f "$OLD_LOG"
+mv "$CURRENT_LOG" "$OLD_LOG"
 ```
-
 
 This approach keeps your logs manageable while preserving recent history for troubleshooting. You can schedule these scripts using Task Scheduler on Windows or cron on Linux.
 
@@ -205,9 +240,8 @@ Some other improvements I'm thinking about, but won't implement unless there is 
 
 - **Support for secured connections.** This would enable the script to work even if "Secured connections" is set to "Required" within the Plex server.
 - **Report number of streams rather than just checking for 0.** Instead of only detecting whether there are zero streams, report how many active streams are running so you can decide based on count thresholds. 
-- **Output to logs instead of screen.** Add or improve logging so that script output goes to log files rather than just the console, useful for monitoring and debugging. 
-- **Sleep option, instead of power down.** Provide an option to put the machine into sleep/standby rather than fully powering it down when no active streams are detected. 
-- **Test command line option.** Add a “dry-run” or “test” command line flag that will simulate the shutdown check without executing the shutdown, for validation purposes. 
+- **Output to logs instead of screen.** Remove the need to redirect output by allowing configuration in the script to output logs to terminal, file, both or none. Handle log rotation automatically.
+- **Sleep option, instead of power down.** Provide an option to put the server into sleep/standby rather than fully powering it down when no active streams are detected. 
 
 ## 📝 Attribution
 - Plex is a registered trademark of Plex, Inc. This tool is not affiliated with or endorsed by Plex, Inc.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ This script is useful for people who have no requirement to run their Plex serve
 Despite being small, these scripts have some useful features:
 
 * 🖥️ Works on Windows and Linux (and possibly macOS)
-* ⚙️ Easy to set up, there is (literally) only one option that you must configure.
+* ⚙️ Easy to set up, there is only one option that you _**must**_ configure.
 * 🎬 Will not shut down a machine if there are active Plex streams (audio or video).
 * 📥 Will not shut down a machine if there are active Plex downloads.
 * 📺 Will not shut down a machine if live TV is being watched or recorded.
+* 🧩 Will not shut down a machine if certain processes (Plex related or not) are running.
+* 🏠 Will not shutdown a machine if certain devices are active on the network (e.g. a television).
 * ⏳ Will not force a machine to shut down for a (configurable) period of time after power up.
 
 ## 📦 Download
@@ -29,15 +31,21 @@ Despite being small, these scripts have some useful features:
 
 To configure the script, open it up in your preferred text editor. For Windows, Notepad will do. For Linux, I recommend [nano](https://www.nano-editor.org/) which usually comes preinstalled with most distributions.
 
-There are two things in the code you can easily change. You must change the `PLEX_TOKEN` setting, the other one is optional:
+Only one setting (your `PLEX_TOKEN`) is required to get this script running. You can leave everything else as-is and the script will work perfectly fine.
+
+### Basic configuration options
 
 - **`PLEX_TOKEN`**  
   The script uses the Plex API in order to determine whether or not anything is streaming. To do this, it needs a token to use for authentication. Plex provides instructions on how to find the token for your Plex server [here](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/). 
 
-  You should modify this line to include your token (capitalisation is important). If you provide an invalid token then the script will always report that something is streaming. The token in the code (`abcd1234efgh5678`) is invalid and will not work.
+  You should modify this line to include your token (capitalisation is important). If you provide an invalid token then the script will display an error and stop. The default token in the code (`abcd1234efgh5678`) is invalid and will never work.
 
 > [!CAUTION]
 > You should never share your Plex token with anyone else.
+
+### Advanced configuration options
+
+You do not have to edit any of these settings. The script works fine with the defaults and these options are only for fine-tuning behaviour.
 
 - **`MIN_UPTIME`**  
   This is the minimum amount of time (in seconds) that a server must have been running (the “uptime”) before the script will work. The default (and recommended) value is `7200` which equates to 2 hours.
@@ -47,11 +55,19 @@ There are two things in the code you can easily change. You must change the `PLE
 > [!IMPORTANT]
 > If you set this value too low, then your server may turn off very quickly after you have turned it back on.
 
+- **`BLOCKING_PROCESSES`**  
+  A semi-colon (`;`) separated list of processes that will block shutdown if they are running. This is useful for delaying shutdown until certain tasks (either Plex related or not) finish. The default code includes `Plex Transcoder` here to ensure that the server isn’t incorrectly shut down while Plex is transcoding - even if the Plex API reports no activity.
+
+- **`BLOCKING_ADDRESSES`**  
+  A semi-colon (`;`) separated list of devices that will block shutdown if they are active. Each entry can be an IP address or hostname (e.g. `192.168.0.20;SAMSUNG-TV`) and devices on this list are assumed to be in use if they respond to [ping](https://www.lifewire.com/ping-command-2618099) or appear in [ARP](https://en.wikipedia.org/wiki/Address_Resolution_Protocol). If you want to use IP addresses then it is recommended to configure your router to assign a static (same) IP address to the device to stop it changing.
+
 ## ▶️ Running the script
 
 To run the script, you can either double-click on it or run it from the command line. If you are using Linux then you will probably need to make the script executable with `chmod +x plex-autoshutdown.sh`.
 
 To run on your Plex server, you will need to set up the script to run multiple times over the night. This is to ensure that if the shutdown is blocked because something is being streamed, then it will try again at a later time.
+
+The script will output information to the terminal/console and this is useful to aid in debugging. It is recommended that you redirect the output to a file in case you need to review the logs at a later date to understand why something happened. If you do not trim the logs then this file could get very big. To avoid this issue, you should consider setting up a regular schedule to trim or rotate the log file so it does not grow indefinitely.
 
 ## 🪟 Installation (Windows)
 
@@ -108,8 +124,9 @@ Most modern computer BIOS’ allow you to configure a computer to power on at a 
 
 ## ⚠️ Known issues
 
-- The Plex API will often incorrectly report that content is being streamed for several minutes after it has been stopped. There is no workaround for this.
-- There is no validation of the Plex token. If you've supplied one that doesn't work then the script will incorrectly report that something is being streamed and your server will never shut down.
+- The Plex API may continue reporting that content is being streamed for several minutes after playback stops. There is no workaround for this.
+- The Plex API may fail to report active transcoding. To prevent shutdown during transcoding, the `Plex Transcoder` entry in `BLOCKING_PROCESSES` acts as an effective workaround.
+- The script will not work if "Secured connections" is set to "Required" within Plex.
 
 ## 🛟 Questions/problems?
 
@@ -119,16 +136,11 @@ Please raise an issue at https://github.com/mrsilver76/plex-autoshutdown/issues.
 
 This script currently meets the needs it was designed for, and no major new features are planned at this time. However, the project remains open to community suggestions and improvements. If you have ideas or see ways to enhance the tool, please feel free to submit a [feature request](https://github.com/mrsilver76/plex-autoshutdown/issues).
 
-Some big improvements I'm thinking about implementing:
-
-- **Check for running processes**. Allow a list of processes that, if running, should block shutdown of the server. One example would be `Plex Transcoder.exe` but could be anything else that people want to allow to complete running before shutdown.
-- **Check for online IPs**. Allow a list of IP addresses that, if in use, should block shutdown of the server. One example would be the IP address of your TV set, meaning that if it's on then the script will not shut down the Plex server.
-
 Some other improvements I'm thinking about, but won't implement unless there is demand, are:
 
+- **Support for secured connections.** This would enable the script to work even if "Secured connections" is set to "Required" within the Plex server.
 - **Report number of streams rather than just checking for 0.** Instead of only detecting whether there are zero streams, report how many active streams are running so you can decide based on count thresholds. 
 - **Output to logs instead of screen.** Add or improve logging so that script output goes to log files rather than just the console, useful for monitoring and debugging. 
-- **Check Plex token prior to checking for streams.** Validate the authentication token for Plex Media Server before attempting to check for active streams, to handle auth failures gracefully. 
 - **Sleep option, instead of power down.** Provide an option to put the machine into sleep/standby rather than fully powering it down when no active streams are detected. 
 - **Test command line option.** Add a “dry-run” or “test” command line flag that will simulate the shutdown check without executing the shutdown, for validation purposes. 
 
@@ -137,6 +149,13 @@ Some other improvements I'm thinking about, but won't implement unless there is 
 - With thanks to [https://www.plexopedia.com/plex-media-server/api/](https://www.plexopedia.com/plex-media-server/api/) for Plex API documentation.
 
 ## 🕰️ Version history
+
+### 1.3 (xx March 2026)
+- Added connectivity tests to check if Plex is running and the supplied token is valid.
+- Improved the formatting of the output to make troubleshooting easier.
+- Added support for blocking shutdown if certain processes are running.
+- Added support for blocking shutdown if certain devices are on the network (e.g. a television).
+- Updated the documentation.
 
 ### 1.2 (28th March 2025)
 - Added support for blocking shutdown if live TV is being recorded or viewed.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Despite being small, these scripts have some useful features:
 
 To configure the script, open it up in your preferred text editor. For Windows, Notepad will do. For Linux, I recommend [nano](https://www.nano-editor.org/) which usually comes preinstalled with most distributions.
 
-Only one setting (your `PLEX_TOKEN`) is required to get this script running. You can leave everything else as-is and the script will work perfectly fine.
-
 ### Basic configuration options
+
+Only one setting is required to get this script running. You can leave everything else as-is and the script will work perfectly fine.
 
 - **`PLEX_TOKEN`**  
   The script uses the Plex API in order to determine whether or not anything is streaming. To do this, it needs a token to use for authentication. Plex provides instructions on how to find the token for your Plex server [here](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/). 
@@ -64,13 +64,20 @@ You do not have to edit any of these settings. The script works fine with the de
 
 ## ▶️ Running the script
 
-To run the script, you can either double-click on it or run it from the command line. If you are using Linux then you will probably need to make the script executable with `chmod +x plex-autoshutdown.sh`.
+The script must be placed and run on your Plex server (the same machine Plex is installed on) to correctly detect streams, downloads and other activity. 
 
-To run on your Plex server, you will need to set up the script to run multiple times over the night. This is to ensure that if the shutdown is blocked because something is being streamed, then it will try again at a later time.
+On Linux, you will need to make it executable first by using `chmod +x plex-autoshutdown.sh`.
 
-The script will output information to the terminal/console and this is useful to aid in debugging. It is recommended that you redirect the output to a file in case you need to review the logs at a later date to understand why something happened. If you do not trim the logs then this file could get very big. To avoid this issue, you should consider setting up a regular schedule to trim or rotate the log file so it does not grow indefinitely.
+Before enabling automatic shutdown, run the script in test mode from the command line to confirm that everything is working correctly. When test mode is enabled, the script performs all checks and reports what it would do. Even if a condition would normally block a shutdown, the script will continue running so you can see the full set of results. _**It will never actually shut down your server in this mode!**_
 
-## 🪟 Installation (Windows)
+To use test mode, append any of `/t`, `/test`, `-t`, or `--test` to the command line, irrespective of your operating system:
+
+- Windows: `plex-autoshutdown.bat /test`
+- Linux: `plex-autoshutdown.sh -t`
+
+Once you've confirmed that the script works as expected, you need to configure your operating system to run the script multiple times over the night. This is to ensure that if the shutdown is blocked because something is being streamed or downloaded, then it will try again at a later time.
+
+## 🪟 Automatic scheduling (Windows)
 
 These instructions assume that you want to turn your server off from between midnight and 6am and that you will check the server status every 15 minutes.
 
@@ -100,7 +107,7 @@ You need to set up a scheduled task to run the script:
 - Ensure that “Wake the computer to run this task” is turned off.
 - Click on “OK”.
 
-## 🐧 Installation (Linux)
+## 🐧 Automatic scheduling (Linux)
 
 These instructions assume that you want to turn your server off from between midnight and 5:45am and that you will check the server status every 15 minutes.
 
@@ -115,6 +122,58 @@ You need to set up a cron to run this task:
 - Save the file.
 
 As the script outputs messages, this will be emailed to you. The use of `>/dev/null` ensures that this does not happen but you can also redirect it to a file if you wish.
+
+## 📝 Logging
+
+The script outputs information to the terminal or console detailing whether any streams, downloads, live TV, blocking processes/devices were detected and the decisions the script made. This information is useful for debugging and understanding why a shutdown did or did not occur.
+
+It is recommended to redirect the output to a text file so you can review it later. For example:
+
+- Windows: `plex-autoshutdown.bat > autoshutdown.log 2>&1`
+- Linux: `./plex-autoshutdown.sh > autoshutdown.log 2>&1`
+
+Over time, the log file can grow very large if not managed. To prevent this, you can use a simple rotation script to archive old logs and keep only recent entries. The following code assumes that you write out to `autoshutdown.log` and will maintain up to 7 days of history.
+
+**Windows** (save as `rotate-autoshutdown.bat`)
+```batch
+@echo off
+
+set "LOG_DIR=C:\path\to\logs"
+set "LOG_FILE=%LOG_DIR%\autoshutdown.log"
+
+rem Delete the oldest log
+del "%LOG_DIR%\autoshutdown-7.log" 2>nul
+
+rem Shift logs up by one
+for /l %%i in (6,-1,1) do (
+    ren "%LOG_DIR%\autoshutdown-%%i.log" "autoshutdown-%%~ni%%i+.log" 2>nul
+)
+
+rem Move today's log to autoshutdown-1.log
+move "%LOG_FILE%" "%LOG_DIR%\autoshutdown-1.log" 2>nul
+```
+
+**Linux** (save as `rotate-autoshutdown.sh`)
+```bash
+#!/bin/bash
+
+LOG_DIR="/path/to/logs"
+LOG_FILE="$LOG_DIR/autoshutdown.log"
+
+# Delete the oldest log
+rm -f "$LOG_DIR/autoshutdown-7.log"
+
+# Shift logs up by one
+for i in 6 5 4 3 2 1; do
+    mv "$LOG_DIR/autoshutdown-$i.log" "$LOG_DIR/autoshutdown-$((i+1)).log" 2>/dev/null
+done
+
+# Move today's log to autoshutdown-1.log
+mv "$LOG_FILE" "$LOG_DIR/autoshutdown-1.log" 2>/dev/null
+```
+
+
+This approach keeps your logs manageable while preserving recent history for troubleshooting. You can schedule these scripts using Task Scheduler on Windows or cron on Linux.
 
 ## 🔌 Automatic power on
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Some other improvements I'm thinking about, but won't implement unless there is 
 
 ## 🕰️ Version history
 
-### 1.3 (xx March 2026)
+### 1.3 (14th March 2026)
 - Added connectivity tests to check if Plex is running and the supplied token is valid.
 - Added validation that the supplied Plex token is not blank or set to the placeholder.
 - Improved the formatting of the output to make troubleshooting and logging easier.

--- a/README.md
+++ b/README.md
@@ -123,16 +123,28 @@ You need to set up a cron to run this task:
 
 As the script outputs messages, this will be emailed to you. The use of `>/dev/null` ensures that this does not happen but you can also redirect it to a file if you wish.
 
+## 🔌 Automatic power on
+
+Once you have the script set up to shut down your machine, you also need some way to start it back up again in the morning.
+
+The easiest way is to change your BIOS settings to power on the machine at a specific time. To access the BIOS, you will usually need to press a key such as <kbd>Del</kbd>, <kbd>F1</kbd>, <kbd>F2</kbd>, <kbd>F10</kbd> or <kbd>Esc</kbd> immediately after powering on. If you’re unsure which key to use for your computer or motherboard, check the manufacturer’s instructions or search online.
+
+You can usually find the power-on scheduling option in your BIOS under a "Power" or "Advanced" menu, often called something like "Resume by RTC Alarm", "Wake on RTC", or "Wake on Alarm". If you don’t see it, check any "Power Management" or "ACPI" sections. 
+
+> [!TIP]
+> Whilst you are configuring this, I recommend you also enable the “automatically power on after power loss” option. This means that if you have a power cut then the server will automatically boot again when power is restored.
+
+
 ## 📝 Logging
 
-The script outputs information to the terminal or console detailing whether any streams, downloads, live TV, blocking processes/devices were detected and the decisions the script made. This information is useful for debugging and understanding why a shutdown did or did not occur.
+The script outputs information to the terminal or console, showing whether any streams, downloads, live TV, blocking processes, or devices were detected, and what decisions the script made. This information can be useful for review or debugging. **Most of the time you won't need this output**, which is why the instructions either do nothing with it (on Windows) or redirect it to `/dev/null` (on Linux).
 
-It is recommended to redirect the output to a text file so you can review it later. For example:
+If you do decide you need to review the output (e.g. to troubleshoot an issue), you can redirect the output to a file by appending a redirect to the end of the command:
 
-- Windows: `plex-autoshutdown.bat > autoshutdown.log 2>&1`
-- Linux: `./plex-autoshutdown.sh > autoshutdown.log 2>&1`
+- Windows: `plex-autoshutdown.bat > "C:\path\to\logs\autoshutdown.log" 2>&1`
+- Linux: `./plex-autoshutdown.sh > /path/to/logs/autoshutdown.log 2>&1`
 
-Over time, the log file can grow very large if not managed. To prevent this, you can use a simple rotation script to archive old logs and keep only recent entries. The following code assumes that you write out to `autoshutdown.log` and will maintain up to 7 days of history.
+If you intend to keep this redirect in place indefinitely then, over time, the log file will grow very large. To prevent this, you can use a simple rotation script that runs daily to archive old logs and keep only recent entries. The following code should be called once a day (for example, on start up), assumes that you write out to `autoshutdown.log` and will maintain up to 7 days of history.
 
 **Windows** (save as `rotate-autoshutdown.bat`)
 ```batch
@@ -174,13 +186,6 @@ mv "$LOG_FILE" "$LOG_DIR/autoshutdown-1.log" 2>/dev/null
 
 
 This approach keeps your logs manageable while preserving recent history for troubleshooting. You can schedule these scripts using Task Scheduler on Windows or cron on Linux.
-
-## 🔌 Automatic power on
-
-Most modern computer BIOS’ allow you to configure a computer to power on at a specific time. You will need to Google the brand of your computer/motherboard to find out how to access the BIOS. If it usually through pressing one of the F keys on power up.
-
-> [!TIP]
-> Whilst you are configuring this, I recommend you also enable the “automatically power on after power loss” option. This means that if you have a power cut then the server will automatically boot again when power is restored.
 
 ## ⚠️ Known issues
 

--- a/plex-autoshutdown.bat
+++ b/plex-autoshutdown.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 rem Plex Autoshutdown (for Windows)
-rem Version 1.2 (released 28th March 2025)
+rem Version 1.3 (released 14th March 2025)
 rem https://github.com/mrsilver76/plex-autoshutdown
 rem
 rem A simple script which, when executed, will check that no-one is using Plex
@@ -34,7 +34,10 @@ rem WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 rem
 rem For more information, please refer to https://unlicense.org
 
-rem ----- Configuration settings -------------------------------------------
+rem ----- Basic configuration settings -----------------------------------
+rem
+rem Only one setting (your PLEX_TOKEN) is required to get this script running.
+rem You can leave everything else as-is and the script will work perfectly fine.
 
 rem PLEX_TOKEN
 rem The API token required for this script to be able to access Plex.
@@ -42,6 +45,11 @@ rem Do not share your token with anyone. For details on how to find this, see
 rem https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
 
 set PLEX_TOKEN=abcd1234efgh5678
+
+rem ----- Advanced configuration settings --------------------------------
+rem
+rem You do not have to change any of these settings. The script works fine
+rem with the defaults. These options are only for fine-tuning behaviour.
 
 rem MIN_UPTIME
 rem The minimum amount of time (in seconds) the server needs to be running
@@ -51,63 +59,202 @@ rem for that period of time. The recommended value is 7200 = 2 hours.
 
 set MIN_UPTIME=7200
 
-rem ----- End of configuration settings. Code starts here ------------------
+rem BLOCKING_PROCESSES
+rem A semi-colon (;) separated list of processes that will block shutdown
+rem if they are running. This is useful for delaying shutdown until certain
+rem tasks (either Plex related or not) finish. For example we include
+rem "Plex Transcoder.exe" here to ensure that the server isn’t incorrectly
+rem shut down while Plex is transcoding - even if the Plex API reports no
+rem activity.
 
-rem Get the uptime
+set BLOCKING_PROCESSES=Plex Transcoder.exe
 
-Set uptime_seconds=
+rem BLOCKING_ADDRESSES
+rem A semi-colon (;) separated list of devices that will block shutdown if
+rem they are active. Each entry can be an IP address or hostname
+rem (e.g. "192.168.0.20;SAMSUNGTV") and devices on this list are assumed to
+rem be in use if they respond to a network ping. If you want to use
+rem IP addresses then it is recommended to configure your router to
+rem assign a static (same) IP address to the device to stop it changing.
 
-(for /F "tokens=1,* delims==" %%v in (
-    'wmic path Win32_PerfFormattedData_PerfOS_System get SystemUptime /format:list ^| findstr "[0-9]"'
-) do (
-    Set uptime_seconds=%%w
-))
+set BLOCKING_ADDRESSES=
+
+rem ----- End of configuration settings. Code starts here ----------------
+
+set VERSION=1.3
+set DO_SHUTDOWN=true
+
+rem Parse arguments looking for test mode defined
+
+set "TEST_MODE=false"
+for %%A in (%*) do (
+	if "%%A"=="-t" set "TEST_MODE=true"
+	if "%%A"=="--test" set "TEST_MODE=true"
+	if "%%A"=="/t" set "TEST_MODE=true"
+	if "%%A"=="/test" set "TEST_MODE=true"
+)
+
+rem Display starting up message
+
+if "%TEST_MODE%"=="true" (
+	call :Log Plex Autoshutdown v%VERSION% starting ^(test mode^)...
+) else (
+	call :Log Plex Autoshutdown v%VERSION% starting...
+)
+
+rem Check if the Plex token has been set correctly
+
+if "%PLEX_TOKEN%"=="" (
+    call :Log Error: Plex token is not set
+    exit /b 1
+) else if "%PLEX_TOKEN%"=="abcd1234efgh5678" (
+    call :Log Error: Plex token is set to the default placeholder
+    exit /b 1
+)
+
+rem Check if Plex is running and contactable
+
+curl -s -o "%TEMP%\plex-autoshutdown.tmp" -w "%%{http_code}" --connect-timeout 3 "http://127.0.0.1:32400/status/sessions?X-Plex-Token=%PLEX_TOKEN%" > "%TEMP%\plex_http_code.tmp"
+set /p HTTP_CODE=<"%TEMP%\plex_http_code.tmp"
+del "%TEMP%\plex_http_code.tmp"
+
+rem Plex not running or unreachable
+
+if "%HTTP_CODE%"=="000" (
+    call :Log Error: Plex is not running or not reachable
+    del /f "%TEMP%\plex-autoshutdown.tmp"
+    exit /b 1
+)
+
+REM Plex running but the token is invalid
+
+if "%HTTP_CODE%"=="401" (
+    call :Log Error: Plex is running but the token is invalid
+    del /f "%TEMP%\plex-autoshutdown.tmp"
+    exit /b 1
+)
+
+rem Plex responded with a HTTP code that wasn't 200 (success)
+
+if not "%HTTP_CODE%"=="200" (
+    call :Log Error: Plex responded with HTTP %HTTP_CODE%
+    del /f "%TEMP%\plex-autoshutdown.tmp"
+    exit /b 1
+)
+
+rem Something responded, but it doesn't look like Plex
+
+findstr /c:"<MediaContainer" "%TEMP%\plex-autoshutdown.tmp" >nul
+if errorlevel 1 (
+    call :Log Error: Response does not appear to be Plex
+    del /f "%TEMP%\plex-autoshutdown.tmp"
+    exit /b 1
+)
+
+rem Get the uptime and check it's not less than the configured amount
+
+set uptime_seconds=
+
+for /f %%i in ('powershell.exe -NoProfile -NonInteractive -Command "[int]((New-TimeSpan -Start (Get-CimInstance Win32_OperatingSystem).LastBootUpTime -End (Get-Date)).TotalSeconds)"') do (
+    set uptime_seconds=%%i
+)
 
 if %uptime_seconds% LSS %MIN_UPTIME% (
-	echo Script terminated. Uptime is %uptime_seconds% seconds, which is less than %MIN_UPTIME%.
-	exit /b
+	call :Log Uptime is %uptime_seconds% seconds, which is less than %MIN_UPTIME%
+    set DO_SHUTDOWN=false
 )
 
 rem Check if Plex has any active streams
 
-curl -s "http://127.0.0.1:32400/status/sessions?X-Plex-Token=%PLEX_TOKEN%" | find /I "MediaContainer size=""0"">" >NUL
+curl -s "http://127.0.0.1:32400/status/sessions?X-Plex-Token=%PLEX_TOKEN%" -o "%TEMP%\plex-autoshutdown.tmp" >NUL
+find /I "MediaContainer size=""0"">" "%TEMP%\plex-autoshutdown.tmp" >NUL
 if %errorlevel%==1 (
-	echo Script terminated. Plex is streaming.
-	exit /b
+    call :Log Plex is streaming content
+	set DO_SHUTDOWN=false
 )
 
 rem Check if Plex is downloading
 
 curl -s "http://127.0.0.1:32400/activities?X-Plex-Token=%PLEX_TOKEN%" -o "%TEMP%\plex-autoshutdown.tmp" >NUL
-
 find /I "type=""media.download""" "%TEMP%\plex-autoshutdown.tmp" >NUL
 if %errorlevel%==0 (
-    echo Script terminated. Plex is downloading.
-	del /f "%TEMP%\plex-autoshutdown.tmp"
-	exit /b
+    call :Log Plex is downloading content
+	set DO_SHUTDOWN=false
 ) 
 
 rem Check if Plex is transcoding
 
 find /I "type=""media.offline.transcode""" "%TEMP%\plex-autoshutdown.tmp" >NUL
 if %errorlevel%==0 (
-	echo Script terminated. Plex is transcoding.
-	del /f "%TEMP%\plex-autoshutdown.tmp"
-	exit /b
+	call :Log Plex is transcoding content
+	set DO_SHUTDOWN=false
 )
 
 rem Check if Plex is streaming or recording live TV
 
 find /I "type=""grabber.grab""" "%TEMP%\plex-autoshutdown.tmp" >NUL
 if %errorlevel%==0 (
-	echo Script terminated. Plex is streaming or recording live TV.
-	del /f "%TEMP%\plex-autoshutdown.tmp"
-	exit /b
+	call :Log Plex is streaming or recording live TV
+	set DO_SHUTDOWN=false
 )
+
+rem Clean up
 
 del /f "%TEMP%\plex-autoshutdown.tmp"
 
+rem Check if any processes are running that would block shutdown
+
+if defined BLOCKING_PROCESSES (
+    for %%P in (%BLOCKING_PROCESSES%) do (
+        set PROC_NAME=%%P
+        set PROC_NAME=!PROC_NAME:;=!
+        tasklist /FI "IMAGENAME eq !PROC_NAME!" 2>NUL | find /I "!PROC_NAME!" >NUL
+        if !errorlevel!==0 (
+            call :Log Found process running: !PROC_NAME!
+            set DO_SHUTDOWN=false
+        )
+    )
+)
+
+rem Check if any local addresses are in use that would block shutdown
+rem
+rem Note: Early versions also checked the ARP cache, but dynamic entries can
+rem remain in both Windows and Linux for hours after a device powers off.
+rem In testing, a TV turned off 5 hours earlier was still listed in the ARP
+rem cache, making this method unreliable for detecting active devices.
+
+if defined BLOCKING_ADDRESSES (
+    for %%T in (%BLOCKING_ADDRESSES%) do (
+ 
+        rem Ping the address/hostname to see if device is online
+
+        ping -n 1 -w 2000 %%T | find "TTL=" >NUL
+        if !errorlevel! EQU 0 (
+            call :Log Found active device at %%T
+            set DO_SHUTDOWN=false
+        )
+    )
+)
+
 rem Shut down the server
 
-echo Shutting down now...
-shutdown /s /f
+if "%DO_SHUTDOWN%"=="false" (
+    call :Log Autoshutdown finished ^(shutdown blocked^)
+    exit /b 1
+)
+
+if "%TEST_MODE%"=="true" (
+	call :Log Shutdown would happen now ^(blocked by test mode^)
+) else (
+	call :Log Shutting down now...
+	shutdown /s /t 0
+)
+exit /b 0
+
+rem Log
+rem Echos text to stdout prefixed with the date and time, ideal for
+rem sending to a text log for monitoring and debugging purposes
+:Log
+for /f "delims=" %%I in ('powershell -NoProfile -NonInteractive -Command "Get-Date -Format \"yyyy-MM-dd HH:mm:ss\" "') do set "TS=%%I"
+echo [%TS%] %*
+goto :eof

--- a/plex-autoshutdown.sh
+++ b/plex-autoshutdown.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Plex Autoshutdown (for Linux)
-# Version 1.2 (released 28th March 2025)
+# Version 1.3 (released 14th March 2025)
 # https://github.com/mrsilver76/plex-autoshutdown
 #
 # A simple script which, when executed, will check that no-one is using Plex
@@ -33,14 +33,22 @@
 #
 # For more information, please refer to https://unlicense.org
 
-# ----- Configuration settings -------------------------------------------
+# ----- Basic configuration settings -----------------------------------
+#
+# Only one setting (your PLEX_TOKEN) is required to get this script running.
+# You can leave everything else as-is and the script will work perfectly fine.
 
 # PLEX_TOKEN
 # The API token required for this script to be able to access Plex.
 # Do not share your token with anyone. For details on how to find this, see
 # https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
 
-PLEX_TOKEN=abcd1234efgh5678
+PLEX_TOKEN="abcd1234efgh5678"
+
+# ----- Advanced configuration settings --------------------------------
+#
+# You do not have to change any of these settings. The script works fine
+# with the defaults. These options are only for fine-tuning behaviour.
 
 # MIN_UPTIME
 # The minimum amount of time (in seconds) the server needs to be running
@@ -50,57 +58,200 @@ PLEX_TOKEN=abcd1234efgh5678
 
 MIN_UPTIME=7200
 
-# ----- End of configuration settings. Code starts here ------------------
+# BLOCKING_PROCESSES
+# A semi-colon (;) separated list of processes that will block shutdown
+# if they are running. This is useful for delaying shutdown until certain
+# tasks (either Plex related or not) finish. For example we include
+# "Plex Transcoder" here to ensure that the server isn’t incorrectly
+# shut down while Plex is transcoding - even if the Plex API reports no
+# activity.
 
-readonly MIN_UPTIME
-readonly PLEX_TOKEN
+BLOCKING_PROCESSES="Plex Transcoder"
 
-# Get the uptime in seconds
+# BLOCKING_ADDRESSES
+# A semi-colon (;) separated list of devices that will block shutdown if
+# they are active. Each entry can be an IP address or hostname
+# (e.g. "192.168.0.20;SAMSUNGTV") and devices on this list are assumed to
+# be in use if they respond to a network ping. If you want to use
+# IP addresses then it is recommended to configure your router to
+# assign a static (same) IP address to the device to stop it changing.
+
+BLOCKING_ADDRESSES=""
+
+# ----- End of configuration settings. Code starts here ----------------
+
+VERSION="1.3"
+DO_SHUTDOWN=true
+
+# Log
+# Echos text to stdout prefixed with the date and time, ideal for
+# sending to a text log for monitoring and debugging purposes
+Log() {
+    TS=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[$TS] $*"
+}
+
+# Parse arguments looking for test mode defined
+
+TEST_MODE=false
+for arg in "$@"; do
+	lower_arg="${arg,,}"
+	case "$lower_arg" in
+		-t|--test|/t|/test)
+			TEST_MODE=true
+			;;
+	esac
+done
+
+# Display starting up message
+
+if [ "$TEST_MODE" = true ]; then
+    Log "Plex Autoshutdown v$VERSION starting (test mode)..."
+else
+    Log "Plex Autoshutdown v$VERSION starting..."
+fi
+
+# Check if the Plex token has been set correctly
+
+if [ -z "$PLEX_TOKEN" ]; then
+    Log "Error: Plex token is not set"
+    exit 1
+elif [ "$PLEX_TOKEN" = "abcd1234efgh5678" ]; then
+    Log "Error: Plex token is set to the default placeholder"
+    exit 1
+fi
+
+# Check if Plex is running and contactable
+
+rm -f "/tmp/plex-autoshutdown.tmp"
+HTTP_CODE=$(curl -s -o "/tmp/plex-autoshutdown.tmp" -w "%{http_code}" --connect-timeout 3 "http://127.0.0.1:32400/status/sessions?X-Plex-Token=$PLEX_TOKEN")
+
+# Plex not running or unreachable
+
+if [ "$HTTP_CODE" = "000" ]; then
+    Log "Error: Plex is not running or not reachable"
+    rm -f "/tmp/plex-autoshutdown.tmp"
+    exit 1
+fi
+
+# Plex running but the token is invalid
+
+if [ "$HTTP_CODE" = "401" ]; then
+    Log "Error: Plex is running but the token is invalid"
+    rm -f "/tmp/plex-autoshutdown.tmp"
+    exit 1
+fi
+
+# Plex responded with a HTTP code that wasn't 200 (success)
+
+if [ "$HTTP_CODE" != "200" ]; then
+    Log "Error: Plex responded with HTTP $HTTP_CODE"
+    rm -f "/tmp/plex-autoshutdown.tmp"
+    exit 1
+fi
+
+# Something responded, but it doesn't look like Plex
+
+if ! grep -q "<MediaContainer" "/tmp/plex-autoshutdown.tmp"; then
+    Log "Error: Response does not appear to be Plex"
+    rm -f "/tmp/plex-autoshutdown.tmp"
+    exit 1
+fi
+
+# Get the uptime and check it's not less than the configured amount
 
 uptime_seconds=$(awk '{print int($1)}' /proc/uptime)
 
-if ((uptime_seconds < MIN_UPTIME)); then
-	echo Script terminated. Uptime is $uptime_seconds seconds, which is less than $MIN_UPTIME.
-	exit 1
+if (( uptime_seconds < MIN_UPTIME )); then
+    Log "Uptime is $uptime_seconds seconds, which is less than $MIN_UPTIME"
+    DO_SHUTDOWN=false
 fi
 
 # Check if Plex has any active streams
 
-if ! curl -s "http://127.0.0.1:32400/status/sessions?X-Plex-Token=$PLEX_TOKEN" | grep -i "MediaContainer size=\"0\">" >/dev/null; then
-	echo Script terminated. Plex is streaming.
-	exit 1
+if ! grep -q 'MediaContainer size="0">' "/tmp/plex-autoshutdown.tmp"; then
+    Log "Plex is streaming content"
+    DO_SHUTDOWN=false
 fi
 
 # Check if Plex is downloading
 
-curl -s "http://127.0.0.1:32400/activities?X-Plex-Token=$PLEX_TOKEN" > /tmp/plex-autoshutdown.tmp
-
-if grep -qE 'type="media\.download"' /tmp/plex-autoshutdown.tmp; then
-	echo Script terminated. Plex is downloading.
-	rm -f /tmp/plex-autoshutdown.tmp
-	exit 1
+curl -s "http://127.0.0.1:32400/activities?X-Plex-Token=$PLEX_TOKEN" -o "/tmp/plex-autoshutdown.tmp"
+if grep -q 'type="media.download"' "/tmp/plex-autoshutdown.tmp"; then
+    Log "Plex is downloading content"
+    DO_SHUTDOWN=false
 fi
 
 # Check if Plex is transcoding
 
-if grep -qE 'type="media\.offline\.transcode"' /tmp/plex-autoshutdown.tmp; then
-	echo Script terminated. Plex is transcoding.
-	rm -f /tmp/plex-autoshutdown.tmp
-	exit 1
+if grep -q 'type="media.offline.transcode"' "/tmp/plex-autoshutdown.tmp"; then
+    Log "Plex is transcoding content"
+    DO_SHUTDOWN=false
 fi
 
 # Check if Plex is streaming or recording live TV
 
-if grep -qE 'type="grabber\.grab"' /tmp/plex-autoshutdown.tmp; then
-	echo Script terminated. Plex is streaming or recording live TV.
-	rm -f /tmp/plex-autoshutdown.tmp
-	exit 1
+if grep -q 'type="grabber.grab"' "/tmp/plex-autoshutdown.tmp"; then
+    Log "Plex is streaming or recording live TV"
+    DO_SHUTDOWN=false
 fi
 
-rm -f /tmp/plex-autoshutdown.tmp
+# Clean up
+
+rm -f "/tmp/plex-autoshutdown.tmp"
+
+# Check if any processes are running that would block shutdown
+
+if [[ -n "$BLOCKING_PROCESSES" ]]; then
+    IFS=';' read -ra PROC_ARRAY <<< "$BLOCKING_PROCESSES"
+    for PROC_NAME in "${PROC_ARRAY[@]}"; do
+
+        # Skip empty strings
+        [[ -z "$PROC_NAME" ]] && continue
+
+        if ps -ef | grep -i "$PROC_NAME" | grep -v grep >/dev/null; then
+            Log "Found process running: $PROC_NAME"
+            DO_SHUTDOWN=false
+        fi
+    done
+fi
+
+# Check if any local addresses are in use that would block shutdown
+#
+# Note: Early versions also checked the ARP cache, but dynamic entries can
+# remain in both Windows and Linux for hours after a device powers off.
+# In testing, a TV turned off 5 hours earlier was still listed in the ARP
+# cache, making this method unreliable for detecting active devices.
+
+# Only run if BLOCKING_ADDRESSES is defined
+if [[ -n "$BLOCKING_ADDRESSES" ]]; then
+    IFS=';' read -ra ADDR_ARRAY <<< "$BLOCKING_ADDRESSES"
+
+    # Loop over each address/hostname
+    for TARGET in "${ADDR_ARRAY[@]}"; do
+
+        # Ping the address/hostname to see if device is online
+
+        if ping -c 1 -W 2 "$TARGET" &>/dev/null; then
+            Log "Found active device at $TARGET"
+            DO_SHUTDOWN=false
+        fi
+
+    done
+fi
 
 # Shut down the server
 
-echo Shutting down now...
-sudo shutdown -h now
+if [ $DO_SHUTDOWN = false ]; then
+    Log "Autoshutdown finished (shutdown blocked)"
+    exit 1
+fi
+
+if [ "$TEST_MODE" = true ]; then
+    Log "Shutdown would happen now (blocked by test mode)"
+else
+    Log "Shutting down now..."
+    sudo shutdown -h now
+fi
+
 exit 0


### PR DESCRIPTION
- Added connectivity tests to check if Plex is running and the supplied token is valid.
- Added validation that the supplied Plex token is not blank or set to the placeholder.
- Improved the formatting of the output to make troubleshooting and logging easier.
- Adjusted the logic so all checks run even if earlier ones fail, making it easier to see every reason shutdown might be blocked.
- Added support for blocking shutdown if certain processes are running.
- Added support for blocking shutdown if certain devices are on the network (e.g. a television).
- Added a test mode to enable verification of the logic without shutting down the server.
- Removed use of deprecated `wmic` command and replaced it with PowerShell for uptime checks (Windows). 
- Updated the documentation.